### PR TITLE
Add documentation site link to README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -23,7 +23,9 @@ knitr::opts_chunk$set(
   [![Codecov test coverage](https://codecov.io/gh/manuhuth/coconots/branch/main/graph/badge.svg)](https://app.codecov.io/gh/manuhuth/coconots?branch=main)
   <!-- badges: end -->
 
-  Functions to analyse time series consisting of low counts are provided. The 
+  📖 **Documentation:** <https://manuhuth.github.io/coconots/>
+
+  Functions to analyse time series consisting of low counts are provided. The
   focus in the current version is on practical models that can  capture first 
   and higher-order dependence based on the work of Joe (1996). Both equidispersed 
   and overdispersed marginal distributions of data can be modelled. Regression 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ status](https://www.r-pkg.org/badges/version/coconots)](https://CRAN.R-project.o
 coverage](https://codecov.io/gh/manuhuth/coconots/branch/main/graph/badge.svg)](https://app.codecov.io/gh/manuhuth/coconots?branch=main)
 <!-- badges: end -->
 
+📖 **Documentation:** <https://manuhuth.github.io/coconots/>
+
 Functions to analyse time series consisting of low counts are provided.
 The focus in the current version is on practical models that can capture
 first and higher-order dependence based on the work of Joe (1996). Both


### PR DESCRIPTION
Adds a prominent link to the pkgdown documentation site (<https://manuhuth.github.io/coconots/>) directly below the badge block, in both `README.Rmd` (source) and the generated `README.md`.