### PR TITLE
Fix Codecov coverage upload (secret name + files input)

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -66,10 +66,12 @@ jobs:
         with:
           # Coverage is informational; don't fail the build on upload hiccups.
           fail_ci_if_error: false
-          file: ./cobertura.xml
+          # codecov-action@v5 expects `files` (plural); `file` is silently ignored.
+          files: ./cobertura.xml
           plugins: noop
           disable_search: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          # The repo's Codecov upload token is stored under the secret name CODECOV.
+          token: ${{ secrets.CODECOV }}
 
       - name: Show testthat output
         if: always()


### PR DESCRIPTION
The coverage upload was silently failing (`Token length: 0`, `Found 0 coverage files`). Two fixes:

1. **Token** — the repo secret is named `CODECOV` (created 2023), not `CODECOV_TOKEN`. Point the action at `secrets.CODECOV`.
2. **Input** — `codecov-action@v5` uses `files` (plural); `file` was ignored, so with `disable_search` it found no report.

No new secret needed — reuses the existing `CODECOV` token.