### PR TITLE
Fix Julia-bridge robustness, cocoReg_cov xreg, and cocoSoc julia forwarding

### DIFF
--- a/R/cocoBoot.R
+++ b/R/cocoBoot.R
@@ -52,7 +52,7 @@ cocoBoot <- function(coco, numb.lags = 21, rep.Bootstrap = 1000,
     addJuliaFunctions()
     coco_boot <- JuliaConnectoR::juliaGet( JuliaConnectoR::juliaCall("cocoBoot", coco$julia_reg, 1:numb.lags, rep.Bootstrap, 1-confidence))
     #acfdata <- coco_boot$values[[2]]
-    ac <- t(coco_boot$values[[1]]) 
+    ac <- t(getJuliaValue(coco_boot, "pacfs"))
     #confidence_bands <- data.frame(cbind(coco_boot$values[[3]], coco_boot$values[[4]]))
     #colnames(confidence_bands) <- c("upper", "lower")
   } else {

--- a/R/cocoForecastOneStep.R
+++ b/R/cocoForecastOneStep.R
@@ -26,15 +26,15 @@ cocoForecastOneStep <- function(coco, max=NULL, epsilon=1e-12, xcast=NULL,
     }
     coco_forecast <- JuliaConnectoR::juliaGet( JuliaConnectoR::juliaCall("cocoPredictOneStep",
                                                                          coco$julia_reg, 0:max_use, xcast))
-    densities <- coco_forecast$values[[4]]
+    densities <- getJuliaValue(coco_forecast, "probabilities")
     if (is.null(max)){
       cumulative <- cumsum(densities)
       index_use <- min(which(cumulative >= 1-epsilon))
       densities <- densities[1:index_use]
     }
     
-    mode <- coco_forecast$values[[1]]
-    median <- coco_forecast$values[[2]]
+    mode <- getJuliaValue(coco_forecast, "prediction_mode")
+    median <- getJuliaValue(coco_forecast, "prediction_median")
   } else {
     if (length(seasonality == 1)) {
       seasonality = c(seasonality, seasonality + 1)

--- a/R/cocoPit.R
+++ b/R/cocoPit.R
@@ -55,8 +55,8 @@ cocoPit <- function(coco, J = 10, conf.alpha = 0.05, julia=FALSE) {
     addJuliaFunctions()
     coco_pit <- JuliaConnectoR::juliaGet( JuliaConnectoR::juliaCall("cocoPit", coco$julia_reg, J))
     J_test <- J
-    u <- coco_pit$values[[2]]
-    d <- coco_pit$values[[1]]
+    u <- getJuliaValue(coco_pit, "bins")
+    d <- getJuliaValue(coco_pit, "Pit_values")
   } else {
 
   data <- coco$ts

--- a/R/cocoReg.R
+++ b/R/cocoReg.R
@@ -116,14 +116,14 @@ cocoReg <- function(type, order, data, xreg = NULL,
     
     fit_R <- JuliaConnectoR::juliaGet(fit_no_optimization_in_dict)
 
-    julia_out <- transformJuliaRegOutputToR(xreg=xreg, pars=fit_R[["values"]][[8]],
+    julia_out <- transformJuliaRegOutputToR(xreg=xreg, pars=getJuliaValue(fit_R, "parameter"),
                                             grad=NULL, hes=NULL,
-                                            inv_hes=fit_R[["values"]][[7]],
-                                            se=fit_R[["values"]][[10]],
+                                            inv_hes=getJuliaValue(fit_R, "covariance_matrix"),
+                                            se=getJuliaValue(fit_R, "se"),
                                             data=data,
                                             type=type,
                                             order=order,
-                                            likelihood=fit_R[["values"]][[1]],
+                                            likelihood=getJuliaValue(fit_R, "log_likelihood"),
                                             end_time = end_time,
                                             start_time=start_time, 
                                             julia_reg=fit_no_optimization_in_dict)

--- a/R/cocoReg_cov.R
+++ b/R/cocoReg_cov.R
@@ -14,7 +14,7 @@ cocoReg_cov <- function(type, order, data, xreg, seasonality = c(1, 2), mu = 1e-
   }
 
   if (is.data.frame(xreg)) {
-    data <- as.matrix(xreg)
+    xreg <- as.matrix(xreg)
   }
 
   if ((outer.it <= 0) | (outer.it != round(outer.it))) {

--- a/R/cocoScore.R
+++ b/R/cocoScore.R
@@ -48,8 +48,9 @@ cocoScore <- function(coco, max_x = 50, julia=FALSE) {
   if (!is.null(coco$julia_reg) & julia){
     addJuliaFunctions()
     coco_score <- JuliaConnectoR::juliaGet( JuliaConnectoR::juliaCall("compute_scores", coco$julia_reg, max_x))
-    return(list("log.score" = coco_score$values[[1]], "quad.score" = coco_score$values[[2]],
-                 "rps.score" = coco_score$values[[3]],
+    return(list("log.score" = getJuliaValue(coco_score, "logarithmic_score"),
+                "quad.score" = getJuliaValue(coco_score, "quadratic_score"),
+                "rps.score" = getJuliaValue(coco_score, "ranked_probability_score"),
                 "aic" = 2*length(coco$par) - 2 * coco$likelihood,
                 "bic" = length(coco$par) * log(length(coco$ts)) - 2 * coco$likelihood
                 ))

--- a/R/cocoSoc.R
+++ b/R/cocoSoc.R
@@ -50,9 +50,9 @@ cocoSoc <- function(data, models = "all", print.progress=TRUE,
       
       name_mod <- paste0(name, order)
       
-      fits[[name_mod]] <- cocoReg(type, order, data_use, ...)
+      fits[[name_mod]] <- cocoReg(type, order, data_use, julia = julia, ...)
 
-      scores[[name_mod]] <- cocoScore(fits[[name_mod]], max_x = max_x_score, julia=T)
+      scores[[name_mod]] <- cocoScore(fits[[name_mod]], max_x = max_x_score, julia = julia)
       index <- index + 1
     }
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,26 @@
 utils::globalVariables(c(
   "Time", "Observed", "Fitted", "Residuals", "Lag", "ACF", "x", "p"
 ))
+
+#' Extract a value from a materialised Julia Dict by key name
+#'
+#' `JuliaConnectoR::juliaGet()` materialises a Julia `Dict` into an R list with
+#' parallel `keys` and `values` elements. The order of these elements follows
+#' Julia's hash-determined `Dict` iteration order, which is stable for a given
+#' Julia version but is NOT guaranteed across versions or if keys are
+#' added/renamed on the Julia side. Indexing `values` by integer position is
+#' therefore fragile. This helper looks the value up by key name instead.
+#'
+#' @param julia_dict A list returned by `JuliaConnectoR::juliaGet()` for a Julia
+#'   `Dict`, i.e. containing parallel `keys` and `values` elements.
+#' @param key The Julia dictionary key (character scalar) to retrieve.
+#' @return The value stored under `key`.
+#' @noRd
+getJuliaValue <- function(julia_dict, key) {
+  keys <- as.character(unlist(julia_dict[["keys"]]))
+  idx <- match(key, keys)
+  if (is.na(idx)) {
+    stop(sprintf("Julia result is missing the expected key '%s'.", key))
+  }
+  julia_dict[["values"]][[idx]]
+}


### PR DESCRIPTION
## Summary

Fixes three issues surfaced by an architecture review of the dual R/Julia backend.

### 1. Robust Julia-result reads (was: hash-order-dependent positional indexing)
`JuliaConnectoR::juliaGet()` materialises a Julia `Dict` with its `values` in
hash-determined iteration order, which is stable only *per Julia version*. The
package read results by integer position (`values[[8]]`, `values[[1]]`, …), so a
Julia upgrade or any return-dict key rename could silently shift the mapping.

Added an internal `getJuliaValue(julia_dict, key)` helper (`R/utils.R`) and
switched all positional reads to key-name lookups in `cocoReg`, `cocoScore`,
`cocoPit`, `cocoBoot`, and `cocoForecastOneStep`.

### 2. `cocoReg_cov` data-frame `xreg` coercion
The `is.data.frame(xreg)` branch assigned `data <- as.matrix(xreg)`, overwriting
`data` instead of coercing `xreg`. Now `xreg <- as.matrix(xreg)`.

### 3. `cocoSoc` ignored its own `julia` argument
The internal `cocoScore` call hardcoded `julia = TRUE`. Now `cocoSoc` forwards
its `julia` argument to both `cocoReg` and `cocoScore`, so `julia = FALSE`
(default) runs entirely on the RCPP backend and `julia = TRUE` uses Julia.

## Verification
- Pure-RCPP test suite: 0 failures (16 passed, Julia tests skipped).
- Julia backend (dev-installed locally): full `cocoReg`/`cocoScore`/`cocoPit`/
  `cocoBoot`/`predict`/`cocoSoc` round-trip on both `julia = TRUE/FALSE`; results
  match the RCPP backend.
- `getJuliaValue` unit-tested against a materialised `Dict` under scrambled hash
  order, matrix values, and a missing-key error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
