### PR TITLE
Fix log-likelihood for Poisson models with covariates

### DIFF
--- a/R/cocoReg_cov.R
+++ b/R/cocoReg_cov.R
@@ -189,7 +189,7 @@ cocoReg_cov <- function(type, order, data, xreg, seasonality = c(1, 2), mu = 1e-
       names(pars) <- c("alpha", lambs)
       T <- length(data)
       xreg_matrix <- data.matrix(xreg)
-      likelihood <- -likelihoodGP1cov(20, pars[1], 0, pars[-c(1, 2)], T, seasonality[1], data, xreg_matrix, link_function)
+      likelihood <- -likelihoodGP1cov(20, pars[1], 0, pars[-1], T, seasonality[1], data, xreg_matrix, link_function)
 
       h <- function(par) {
         alpha <- par[1]
@@ -574,7 +574,7 @@ cocoReg_cov <- function(type, order, data, xreg, seasonality = c(1, 2), mu = 1e-
       names(pars) <- c("alpha1", "alpha2", "alpha3", lambs)
       T <- length(data)
       xreg_matrix <- data.matrix(xreg)
-      likelihood <- -likelihoodGP2cov(20, pars[1], pars[2], pars[3], 0, pars[-c(1:4)], T, seasonality[1], seasonality[2], data, xreg_matrix, link_function)
+      likelihood <- -likelihoodGP2cov(20, pars[1], pars[2], pars[3], 0, pars[-c(1:3)], T, seasonality[1], seasonality[2], data, xreg_matrix, link_function)
 
 
       h <- function(par) {


### PR DESCRIPTION
## Summary

The stored log-likelihood — and the `AIC`/`BIC` derived from it — was wrong for **Poisson** models fit **with covariates**, for both order 1 (PAR1) and order 2 (PAR2).

## Root cause

After optimization, `cocoReg_cov()` recomputes the log-likelihood at the fitted parameters. The Poisson covariate paths reused the **Generalized-Poisson** parameter slicing, which is meant to drop the `eta` parameter. Poisson models carry no `eta` in the parameter vector, so the slice also discarded the **first covariate coefficient (`beta1`)**, evaluating the likelihood with the wrong coefficients.

- PAR1 + covariates: `par = [alpha, beta1, ...]` → code used `pars[-c(1, 2)]`, dropping `alpha` **and** `beta1`
- PAR2 + covariates: `par = [alpha1, alpha2, alpha3, beta1, ...]` → code used `pars[-c(1:4)]`, dropping the three alphas **and** `beta1`

## Fix

- PAR1 + cov: `pars[-c(1, 2)]` → `pars[-1]`
- PAR2 + cov: `pars[-c(1:4)]` → `pars[-c(1:3)]`

## Impact

Only the reported `$likelihood` (and `AIC`/`BIC`) was affected. **Parameter estimates and standard errors were always correct** — the optimizer's objective sliced the betas correctly; only the post-hoc recomputation was wrong. The Generalized-Poisson covariate paths were already correct and are unchanged.

## Verification

On the `downloads` dataset with a two-column covariate matrix, the stored `$likelihood` now matches an independent kernel evaluation at the fitted parameters to `0.0e+00`:

| model | stored before fix | stored after fix |
|-------|------------------:|-----------------:|
| PAR1 + cov | -712.03 | **-634.07** |
| PAR2 + cov | incorrect | **-631.99** |
| GP1 + cov | -534.60 | -534.60 (unchanged) |

Full test suite: 0 failed, 0 errors (Julia-dependent tests skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
